### PR TITLE
add breaking change label step

### DIFF
--- a/.github/workflows/update-config-submodule.yml
+++ b/.github/workflows/update-config-submodule.yml
@@ -34,3 +34,15 @@ jobs:
           commit_author: 'dependabot[bot] <support@github.com>'
           commit_user_name: 'dependabot[bot]'
           commit_user_email: 'support@github.com'
+
+  label_as_breaking_change:
+    name: Label as breaking change
+    if: ${{ contains(github.event.pull_request.body, 'breaking change') || contains(github.event.pull_request.body, 'breaking-change') || contains(github.event.pull_request.body, 'breaking_change')}} # not case sensitive
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: breaking-change


### PR DESCRIPTION
add action to dependabot workflow that adds a `breaking-change` label to a dependabot workflow, if the PR body (i.e. the upstream changes) include a variant of "breaking change", that is delimited by space, dash or underscore and case insensitive. This will only have effect if the any commit message includes this term (in its title).

You can find an example [here](https://github.com/doo/submodule-test/runs/6110545004?check_suite_focus=true)