### PR TITLE
prefer setup-python cache over manual pip cache

### DIFF
--- a/pytest/action.yml
+++ b/pytest/action.yml
@@ -11,13 +11,8 @@ runs:
   steps:
   - name: setup
     uses: actions/setup-python@v2
-
-  - name: cache pip
-    uses: actions/cache@v3
     with:
-      path: ~/.cache/pip
-      key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-      restore-keys: ${{ runner.os }}-pip-
+      cache: 'pip' # caching pip dependencies
 
   - name: install dependencies
     shell: bash


### PR DESCRIPTION
see the following example:
[initial run](https://github.com/doo/mllib/actions/runs/3095795292/jobs/5010601844)
[cached run](https://github.com/doo/mllib/actions/runs/3095795292/jobs/5010635588)

can probably further improved using a virtual env and caching that, so that we don't need to install anything