### PR TITLE
use cached virtual environment

### DIFF
--- a/pytest/action.yml
+++ b/pytest/action.yml
@@ -17,15 +17,27 @@ runs:
   - name: setup
     uses: actions/setup-python@v4
     with:
-      cache: 'pip' # caching pip dependencies
       python-version: ${{ steps.python_version.outputs.version }}
+    
+  - name: Cache virtual environment
+    uses: actions/cache@v3
+    id: cache-venv
+    with:
+      path: ./.venv/
+      key: ${{ runner.os }}-venv-${{ hashFiles('requirements.txt', 'setup.py', 'Makefile') }}
 
-  - name: install dependencies
+  - name: Make virtual environment with dependencies
+    if: steps.cache-venv.outputs.cache-hit != 'true'
     shell: bash
     run: |
+      pip install --upgrade pip
+      python -m venv ./.venv
+      source ./.venv/bin/activate
       pip install -r requirements.txt
       pip install pytest
 
   - name: run pytest
     shell: bash
-    run: pytest -s --full-trace ${{ inputs.runtime_arguments }}
+    run: |
+      source ./.venv/bin/activate
+      pytest -s --full-trace ${{ inputs.runtime_arguments }}


### PR DESCRIPTION
- since whole venv is cached, no longer need to cache pip dependencies
- cache key: requirements.txt and setup.py have dependencies, Makefile has python version
- need to activate venv before running pytest

[example run before](https://github.com/doo/mllib/actions/runs/3189976335) (138 seconds)
[example run after](https://github.com/doo/mllib/actions/runs/3190010832) (38 seconds)