### PR TITLE
add version to key

### DIFF
--- a/pytest/action.yml
+++ b/pytest/action.yml
@@ -23,7 +23,7 @@ runs:
     id: cache-venv
     with:
       path: ./.venv/
-      key: ${{ runner.os }}-${{ steps.python_version.outputs.version }}-venv-${{ hashFiles('requirements.txt', 'setup.py') }}
+      key: ${{ runner.os }}-${{ steps.python_version.outputs.version }}-venv-${{ hashFiles('requirements.txt', 'setup.py') }}-v1
 
   - name: Make virtual environment with dependencies
     if: steps.cache-venv.outputs.cache-hit != 'true'


### PR DESCRIPTION
Some caches got invalidated somehow (unfortunately, that happens from time to time in github actions). Since there currently is now way to manually invalidate caches, use this workaround by forcing new ones.